### PR TITLE
Update package.xml

### DIFF
--- a/image_rotate/package.xml
+++ b/image_rotate/package.xml
@@ -45,7 +45,6 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tracetools_transforms</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Removed deprecated dependency causing build errors in image_rotate on ROS2 Humble